### PR TITLE
Correctly check if path is at root

### DIFF
--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -100,7 +100,7 @@ module.exports =
       if path.isAbsolute(file)
         return
       # if path reaches root folder
-      if absolute == path.sep
+      if absolute == path.resolve absolute, '..'
         # show dialog to create a new file
         atom.confirm
           message: 'File '+ file + ' does not exist'


### PR DESCRIPTION
Previous check resulted in an infinite loop on windows because root path isn't '/' or '\'.
This fix should work for both Windows and Unix.

Feel free to correct me.  :)